### PR TITLE
[CLOUD-193]: Wrap app content with antd <App> component

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,7 @@ import React, { FC, useEffect } from 'react'
 import { BrowserRouter, Routes, Route } from 'react-router-dom'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
-import { ConfigProvider } from 'antd'
+import { App as AntdApp, ConfigProvider } from 'antd'
 import { useSelector, useDispatch } from 'react-redux'
 import type { RootState } from 'store/store'
 import { setIsFederation } from 'store/federation/federation/federation'
@@ -105,7 +105,7 @@ export const App: FC<TAppProps> = ({ isFederation, forcedTheme }) => {
     <QueryClientProvider client={queryClient}>
       {import.meta.env.MODE === 'development' && <ReactQueryDevtools />}
       <ConfigProvider theme={antdConfig}>
-        {isFederation ? renderRoutes() : <BrowserRouter>{renderRoutes(basePrefix)}</BrowserRouter>}
+        <AntdApp>{isFederation ? renderRoutes() : <BrowserRouter>{renderRoutes(basePrefix)}</BrowserRouter>}</AntdApp>
       </ConfigProvider>
     </QueryClientProvider>
   )


### PR DESCRIPTION
Wrap app content with antd `<App>` component inside `<ConfigProvider>` to enable `App.useApp()` across the component tree. Required for toolkit's `BlackholeForm` submit notifications.